### PR TITLE
feat: configurable teams mode for council skills

### DIFF
--- a/.claude/skills/Council/SKILL.md
+++ b/.claude/skills/Council/SKILL.md
@@ -10,12 +10,18 @@ You are the **moderator** of a council debate. Your job is to convene diverse sp
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.claude/skills/DeveloperCouncil/SKILL.md
+++ b/.claude/skills/DeveloperCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **team lead** of a developer council. Your job is to convene the rig
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.claude/skills/KnowledgeCouncil/SKILL.md
+++ b/.claude/skills/KnowledgeCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **moderator** of a knowledge management council. Your job is to conv
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.claude/skills/ProductCouncil/SKILL.md
+++ b/.claude/skills/ProductCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **team lead** of a product council. Your job is to convene product-f
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.codex/skills/Council/SKILL.md
+++ b/.codex/skills/Council/SKILL.md
@@ -10,12 +10,18 @@ You are the **moderator** of a council debate. Your job is to convene diverse sp
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.codex/skills/DeveloperCouncil/SKILL.md
+++ b/.codex/skills/DeveloperCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **team lead** of a developer council. Your job is to convene the rig
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.codex/skills/KnowledgeCouncil/SKILL.md
+++ b/.codex/skills/KnowledgeCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **moderator** of a knowledge management council. Your job is to conv
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.codex/skills/ProductCouncil/SKILL.md
+++ b/.codex/skills/ProductCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **team lead** of a product council. Your job is to convene product-f
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: enabled -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,7 +92,7 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-With `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, councils spawn agents in parallel (TeamCreate + Task per agent). Without it, they run sequentially — same verdict, slower. Standalone agents work without any flag.
+With `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (or `teams: enabled` in `config.yaml`), councils spawn agents in parallel (TeamCreate + Task per agent). Without it, they run sequentially — same verdict, slower. Standalone agents work without any flag.
 
 ## Key Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,8 @@ provider routing (`claude`, `gemini`, `codex`).
 
 Required metadata keys in `SKILL.yaml`: `name`, `description`, `argument-hint`,
 and `providers.*.enabled` for each supported runtime. Body in `SKILL.md` is numbered
-steps (Step 1 through 7/8). All council skills follow: gate check, parse input,
+steps (Step 1 through 7/8). All council skills follow: gate check (configurable via
+`teams` key in `config.yaml`), parse input,
 select roster, spawn team, 3 debate rounds, synthesize + teardown, sequential
 fallback. Main session IS the moderator (never spawn one). Maximum roster size 7.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ module.yaml       module metadata (name, version)
 
 Skills define the orchestration. The main session IS the moderator (never spawn a separate moderator). Flow: gate check (agent teams flag) -> parse input -> select roster (max 7) -> spawn team (TeamCreate + parallel Task) -> 3 rounds -> synthesize verdict + teardown (TeamDelete). If agent teams are unavailable, falls back to sequential subagent calls.
 
-Parallel council execution requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `~/.claude/settings.json` env. Without it, same debate runs sequentially.
+Parallel council execution requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `~/.claude/settings.json` env, or `teams: enabled` in `config.yaml`. Without either, same debate runs sequentially.
 
 ### Agent Files (`agents/*.md`)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -50,7 +50,7 @@ Invoke a council or specialist by using its name or slash command. If they don't
 
 - **Agent Definitions:** Agents are defined in `agents/*.md` using YAML frontmatter for metadata (name, model, description, tools) and Markdown for behavioral instructions (Role, Expertise, Constraints).
 - **Skill Definitions:** Skills in `skills/*/SKILL.md` define the orchestration logic. They follow a standard multi-step process: Gate Check -> Parse Input -> Select Specialists -> Spawn Team -> 3-Round Debate -> Synthesis.
-- **Agent Teams:** The framework prefers using the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` feature for parallel agent execution. If disabled, it falls back to sequential task execution.
+- **Agent Teams:** The framework prefers using the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` feature (or `teams: enabled` in `config.yaml`) for parallel agent execution. If disabled, it falls back to sequential task execution.
 - **Modularity:** Avoid hardcoding rosters in skills; refer to `defaults.yaml` or allow the lead to select relevant specialists based on the task context.
 
 ## Model Resolution & Whitelisting

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,6 +80,10 @@ Add to your `~/.claude/settings.json`:
 }
 ```
 
+**Skip the permission prompt**: If you always use agent teams and want to avoid the
+confirmation on each council invocation, set `teams: enabled` in `config.yaml` and
+re-run `make install`. See `defaults.yaml` for all options (`auto`, `enabled`, `sequential`).
+
 ### 5. Running Agents in Gemini CLI
 
 In the Gemini CLI, sub-agents are an experimental feature and must be enabled in your configuration.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # forge-council Makefile
 
-.PHONY: help sync install install-agents install-skills install-skills-claude install-skills-gemini install-skills-codex clean verify verify-skills verify-skills-claude verify-skills-gemini verify-skills-codex test lint check
+.PHONY: help sync install install-agents install-skills install-skills-claude install-skills-gemini install-skills-codex apply-teams-config clean verify verify-skills verify-skills-claude verify-skills-gemini verify-skills-codex test lint check
 
 # Variables
 AGENT_SRC = agents
@@ -10,6 +10,7 @@ SCOPE ?= workspace
 CLAUDE_SKILLS_DST ?= $(if $(filter workspace,$(SCOPE)),$(CURDIR)/.claude/skills,$(HOME)/.claude/skills)
 GEMINI_SKILLS_DST ?= $(HOME)/.gemini/skills
 CODEX_SKILLS_DST ?= $(if $(filter workspace,$(SCOPE)),$(CURDIR)/.codex/skills,$(HOME)/.codex/skills)
+COUNCIL_SKILLS = Council DeveloperCouncil ProductCouncil KnowledgeCouncil
 
 help:
 	@echo "forge-council management commands:"
@@ -42,7 +43,7 @@ install: sync install-agents install-skills
 install-agents: ensure-lib
 	@bash $(LIB_DIR)/install-agents.sh $(AGENT_SRC) --scope "$(SCOPE)"
 
-install-skills: install-skills-claude install-skills-gemini install-skills-codex
+install-skills: install-skills-claude install-skills-gemini install-skills-codex apply-teams-config
 
 install-skills-claude: ensure-lib
 	@if [ "$(SCOPE)" = "all" ]; then \
@@ -72,6 +73,31 @@ install-skills-codex: ensure-lib
 	  echo "Error: Invalid SCOPE '$(SCOPE)'. Use workspace, user, or all."; \
 	  exit 1; \
 	fi
+
+apply-teams-config:
+	@teams=$$(awk '/^teams:/ { sub("^teams: *",""); print; exit }' \
+	  $$(if [ -f config.yaml ]; then echo config.yaml; else echo defaults.yaml; fi)); \
+	teams=$${teams:-auto}; \
+	if [ "$$teams" = "auto" ]; then \
+	  echo "Teams config: auto (no change needed)"; \
+	  exit 0; \
+	fi; \
+	echo "Applying teams config: $$teams"; \
+	dsts=""; \
+	case "$(SCOPE)" in \
+	  workspace) dsts="$(CURDIR)/.claude/skills $(CURDIR)/.codex/skills" ;; \
+	  user)      dsts="$(HOME)/.claude/skills $(HOME)/.codex/skills" ;; \
+	  all)       dsts="$(CURDIR)/.claude/skills $(CURDIR)/.codex/skills $(HOME)/.claude/skills $(HOME)/.codex/skills" ;; \
+	esac; \
+	for dst in $$dsts; do \
+	  for skill in $(COUNCIL_SKILLS); do \
+	    f="$$dst/$$skill/SKILL.md"; \
+	    if [ -f "$$f" ]; then \
+	      sed -i "s/forge-council-teams: auto/forge-council-teams: $$teams/" "$$f"; \
+	      echo "  $$skill: teams=$$teams ($$dst)"; \
+	    fi; \
+	  done; \
+	done
 
 clean: ensure-lib
 	@bash $(LIB_DIR)/install-agents.sh $(AGENT_SRC) --clean

--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ Council mode uses agent teams (parallel spawning). Enable in settings:
 }
 ```
 
+To skip the environment check entirely, add to `config.yaml`:
+
+```yaml
+teams: enabled
+```
+
+Then re-run `make install`. Councils will use agent teams without prompting.
+
 Without this flag, councils fall back to sequential subagent calls — same specialists, same debate, just slower. Standalone agents work without any flags.
 
 ## Skills

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -66,6 +66,9 @@ Expected: all 5 council skills present after `make install-skills-codex` (worksp
 
 ## Agent teams (optional)
 
+If `teams` is set to `enabled` in `config.yaml`, the gate check is skipped at runtime.
+Otherwise, verify the env var:
+
 ```bash
 echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
 # 1 = parallel council mode available (3-round debate runs fastest)

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -57,6 +57,12 @@ models:
   fast: sonnet
   strong: opus
 
+# Teams mode: auto | enabled | sequential
+# - auto: check CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env at runtime
+# - enabled: always use agent teams (skip env check)
+# - sequential: always use sequential mode (skip env check)
+teams: auto
+
 # Provider-specific overrides and whitelists
 gemini:
   models:

--- a/skills/Council/SKILL.md
+++ b/skills/Council/SKILL.md
@@ -10,12 +10,18 @@ You are the **moderator** of a council debate. Your job is to convene diverse sp
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: auto -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/skills/DeveloperCouncil/SKILL.md
+++ b/skills/DeveloperCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **team lead** of a developer council. Your job is to convene the rig
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: auto -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/skills/KnowledgeCouncil/SKILL.md
+++ b/skills/KnowledgeCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **moderator** of a knowledge management council. Your job is to conv
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: auto -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 

--- a/skills/ProductCouncil/SKILL.md
+++ b/skills/ProductCouncil/SKILL.md
@@ -10,12 +10,18 @@ You are the **team lead** of a product council. Your job is to convene product-f
 
 ## Step 1: Gate Check
 
-```bash
-echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
-```
+<!-- forge-council-teams: auto -->
 
-- If `1`: use agent teams (TeamCreate + parallel Task spawning)
-- If `0` or missing: fall back to sequential mode (see Step 8)
+Read the HTML comment above for the configured teams mode:
+
+- **`enabled`**: Agent teams are available. Use TeamCreate + parallel Task spawning. Proceed to Step 2. If TeamCreate fails unexpectedly, fall back to sequential mode (Step 8).
+- **`sequential`**: Use sequential mode directly. Skip to Step 8.
+- **`auto`** (default): Check the environment:
+  ```bash
+  echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
+  ```
+  - If `1`: use agent teams (TeamCreate + parallel Task spawning)
+  - If `0` or missing: fall back to sequential mode (see Step 8)
 
 ## Step 2: Parse Input
 


### PR DESCRIPTION
## Summary

- Add `teams` config key (`auto`|`enabled`|`sequential`) to `defaults.yaml`
- Replace bare bash gate check in all 4 council SKILL.md files with an HTML comment marker (`<!-- forge-council-teams: auto -->`) and tri-modal dispatch logic
- Add `apply-teams-config` Makefile target that post-processes installed SKILL.md files during `make install`, replacing the marker based on the user's `config.yaml` override
- Update documentation across README, INSTALL, VERIFY, CLAUDE, AGENTS, GEMINI, and copilot-instructions

## Motivation

Every council invocation runs `echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"` which triggers a bash permission prompt in Claude Code. Users who always have agent teams enabled want to skip this friction. Setting `teams: enabled` in `config.yaml` and re-running `make install` eliminates the prompt entirely.

## User workflow

```bash
echo "teams: enabled" > config.yaml
make install
```

To revert: remove the `teams` line from `config.yaml` and `make install` again.

## Test plan

- [ ] `make clean && make install` with no config.yaml -- installed SKILL.md files contain `forge-council-teams: auto`
- [ ] Create `config.yaml` with `teams: enabled`, run `make install` -- installed files contain `forge-council-teams: enabled`
- [ ] Invoke `/DeveloperCouncil test` with `enabled` -- proceeds directly without bash prompt
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)