### PR TITLE
fix: codex-compatible install flow with post-processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ config.yaml
 .claude/skills/*
 .codex/agents/*
 .codex/skills/*
+.codex/config.toml
 .gemini/agents/*
 .gemini/skills/*
 .opencode/skills/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,13 @@ for workspace, `~/.claude/~/.gemini/~/.codex` for user installs).
 ```bash
 make install            # install agents + skills
 make install-agents     # install agents using SCOPE (workspace|user|all) across Claude/Gemini/Codex
+make install-codex-agent-config  # Codex compatibility post-processing (temporary Bash implementation) using SCOPE
 make install-skills     # install skills using SCOPE across Claude/Gemini/Codex
 make install-skills-claude  # install Claude skills using SCOPE
 make install-skills-gemini  # install skills only to ~/.gemini/skills/
 make install-skills-codex   # install Codex council skills using SCOPE
 make verify-skills      # verify skills across Claude, Gemini, and Codex
+make verify-codex-agent-config  # verify Codex role TOML/config artifacts
 make clean              # remove previously installed agents
 make verify             # run verification checks from VERIFY.md
 
@@ -36,14 +38,14 @@ Codex `/experimental` toggles persist in `~/.codex/config.toml` under
 
 ```toml
 [features]
-collab = true
+multi_agent = true
 apps = true
 ```
 
 Use CLI helpers to manage persistent state:
 
 ```bash
-codex features enable collab
+codex features enable multi_agent
 codex features enable apps
 codex features list
 ```
@@ -52,8 +54,12 @@ Note: one-off CLI overrides (`--enable` / `--disable`) can temporarily override
 saved config values for that run.
 
 For Codex, specialists are used as **explicit sub-agents**. Installing agents/skills does not auto-run them. Invoke them directly in prompts (for example: `Task: SoftwareDeveloper — [request]`, `Task: SecurityArchitect — [request]`) or through the council skills.
+Codex install flow also generates role config artifacts in `.codex/agents` (`*.toml`, `*.prompt.md`, `forge-council-agents.toml`) and injects a managed block into `.codex/config.toml` (or `~/.codex/config.toml` for `SCOPE=user`).
+Current post-processing implementation is intentionally in `scripts/install-agents-codex.sh` for readability; long-term plan is migration into forge-lib Rust installers.
 
 ## Project Structure
+
+FIXME: Up-to-date documentation is in CLAUDE.md. In case of conflict consult CLAUDE.md instead.
 
 ```
 agents/              # 13 agent definitions (12 rostered + ForensicAgent)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,16 @@ make install-skills-claude    # ./.claude/skills/ (SCOPE=workspace) or ~/.claude
 make install-skills-gemini    # via gemini CLI (skipped if CLI not installed)
 make install-skills-codex     # ./.codex/skills/ (SCOPE=workspace) or ~/.codex/skills/ (SCOPE=user|all)
 make install-skills-opencode  # ./.opencode/skills/ with kebab-case names (SCOPE=workspace|user|all)
+make install-codex-agent-config # Codex compatibility post-processing and .codex/config.toml update (uses SCOPE)
 ```
+
+Codex install also generates:
+- `agents/<Agent>.toml` (model + model_reasoning_effort + prompt_file)
+- `agents/<Agent>.prompt.md` (agent prompt body)
+- `agents/forge-council-agents.toml` (role manifest merged into `config.toml`)
+
+`config.yaml` overrides are respected for Codex model selection (provider tiers and per-agent model tier), with fallback to `defaults.yaml`.
+Current implementation is intentionally in `scripts/install-agents-codex.sh` as a temporary readable fallback; target architecture is migration into forge-lib Rust libraries.
 
 ### 3. Running Agents in Codex
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # forge-council Makefile
 
-.PHONY: help install install-agents install-skills install-skills-claude install-skills-gemini install-skills-codex install-skills-opencode install-teams-config clean verify verify-skills verify-skills-claude verify-skills-gemini verify-skills-codex verify-skills-opencode verify-agents test lint check lib-init
+.PHONY: help install install-agents install-skills install-skills-claude install-skills-gemini install-skills-codex install-skills-opencode install-codex-agent-config install-teams-config clean verify verify-skills verify-skills-claude verify-skills-gemini verify-skills-codex verify-skills-opencode verify-agents verify-codex-agent-config test lint check lib-init
 
 # Variables
 AGENTS = SoftwareDeveloper DatabaseEngineer DevOpsEngineer DocumentationWriter QaTester SecurityArchitect SystemArchitect UxDesigner ProductManager DataAnalyst TheOpponent WebResearcher ForensicAgent
@@ -22,6 +22,7 @@ help:
 	@echo "forge-council management commands:"
 	@echo "  make install                Install agents + skills for all providers (SCOPE=workspace|user|all, default: workspace)"
 	@echo "  make install-agents         Install specialist agents"
+	@echo "  make install-codex-agent-config Codex compatibility post-processing (generates role TOML/config block)"
 	@echo "  make install-skills         Install skills for Claude, Gemini, Codex, and OpenCode"
 	@echo "  make install-skills-claude  Install skills via SCOPE (workspace/user/all)"
 	@echo "  make install-skills-gemini  Install skills via gemini CLI (uses SCOPE)"
@@ -46,11 +47,27 @@ lib-init:
 $(INSTALL_AGENTS) $(INSTALL_SKILLS) $(VALIDATE_MODULE): lib-init
 	@$(MAKE) -C $(LIB_DIR) build
 
-install: install-agents install-skills install-teams-config
+install: install-agents install-codex-agent-config install-skills install-teams-config
 	@echo "Installation complete. Restart your session or reload agents/skills."
 
 install-agents: $(INSTALL_AGENTS)
 	@$(INSTALL_AGENTS) $(AGENT_SRC) --scope "$(SCOPE)"
+
+install-codex-agent-config:
+	@config_file=$$(if [ -f config.yaml ]; then echo config.yaml; else echo defaults.yaml; fi); \
+	if [ "$(SCOPE)" = "all" ]; then \
+	  codex_roots="$(CURDIR)/.codex $(HOME)/.codex"; \
+	elif [ "$(SCOPE)" = "workspace" ]; then \
+	  codex_roots="$(CURDIR)/.codex"; \
+	elif [ "$(SCOPE)" = "user" ]; then \
+	  codex_roots="$(HOME)/.codex"; \
+	else \
+	  echo "Error: Invalid SCOPE '$(SCOPE)'. Use workspace, user, or all."; \
+	  exit 1; \
+	fi; \
+	for codex_root in $$codex_roots; do \
+	  ./scripts/install-agents-codex.sh "$$codex_root" "$$config_file"; \
+	done
 
 install-skills: install-skills-claude install-skills-gemini install-skills-codex install-skills-opencode
 
@@ -144,7 +161,7 @@ install-teams-config: install-skills-claude
 clean: $(INSTALL_AGENTS)
 	@$(INSTALL_AGENTS) $(AGENT_SRC) --clean
 
-verify: verify-skills verify-agents
+verify: verify-skills verify-agents verify-codex-agent-config
 
 verify-skills: verify-skills-claude verify-skills-gemini verify-skills-codex verify-skills-opencode
 
@@ -261,6 +278,43 @@ verify-agents:
 	if [ $$missing -ne 0 ]; then \
 	  echo "Run 'make install' to deploy agents."; \
 	fi; \
+	test $$missing -eq 0
+
+verify-codex-agent-config:
+	@missing=0; \
+	if [ "$(SCOPE)" = "all" ]; then \
+	  dirs="$(CURDIR)/.codex/agents $(HOME)/.codex/agents"; \
+	elif [ "$(SCOPE)" = "workspace" ]; then \
+	  dirs="$(CURDIR)/.codex/agents"; \
+	elif [ "$(SCOPE)" = "user" ]; then \
+	  dirs="$(HOME)/.codex/agents"; \
+	else \
+	  echo "Invalid SCOPE: $(SCOPE)"; exit 1; \
+	fi; \
+	for dir in $$dirs; do \
+	  echo "Verifying Codex role config in $$dir..."; \
+	  cfg="$$(dirname "$$dir")/config.toml"; \
+	  if [ -f "$$cfg" ] && grep -q "BEGIN forge-council agents" "$$cfg"; then \
+	    echo "  ok codex config marker"; \
+	  else \
+	    echo "  missing codex config marker in $$cfg"; \
+	    missing=1; \
+	  fi; \
+	  if [ -f "$$dir/forge-council-agents.toml" ]; then \
+	    echo "  ok forge-council-agents.toml"; \
+	  else \
+	    echo "  missing forge-council-agents.toml"; \
+	    missing=1; \
+	  fi; \
+	  for a in $(AGENTS); do \
+	    if [ -f "$$dir/$$a.toml" ] && [ -f "$$dir/$$a.prompt.md" ]; then \
+	      echo "  ok $$a role config"; \
+	    else \
+	      echo "  missing $$a role config"; \
+	      missing=1; \
+	    fi; \
+	  done; \
+	done; \
 	test $$missing -eq 0
 
 test: $(VALIDATE_MODULE)

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Primary commands:
 ```bash
 make install                 # install agents + skills + teams config (SCOPE=workspace|user|all)
 make install-agents          # install agent artifacts (uses SCOPE)
+make install-codex-agent-config # Codex compatibility post-processing (temporary Bash implementation)
 make install-skills          # install skills for Claude, Gemini, and Codex (uses SCOPE)
 make install-skills-codex    # install native council skills (uses SCOPE)
 make verify                  # run verification checks (13 agents)
+make verify-codex-agent-config # verify Codex role TOML/config artifacts (uses SCOPE)
 ```
 
 ## What it does
@@ -179,6 +181,8 @@ In Codex, specialists are used via **explicit sub-agent invocation**. They are n
 - Use direct invocation style: `Task: SoftwareDeveloper — [request]`
 - Use council skills when you want multi-agent debate: `/DebateCouncil`, `/DeveloperCouncil`, `/ProductCouncil`, `/KnowledgeCouncil`
 - If you do not ask for a specialist/sub-agent, the main session handles the request alone
+- Installation also runs Codex compatibility post-processing that generates role files (`agents/*.toml`, `agents/*.prompt.md`, `agents/forge-council-agents.toml`) and injects them into `.codex/config.toml` (or `~/.codex/config.toml` for `SCOPE=user`).
+- This post-processing is currently implemented in `scripts/install-agents-codex.sh` as a temporary readable fallback; the long-term target is migration into forge-lib Rust binaries.
 
 ## The debate
 

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -64,6 +64,17 @@ ls .codex/skills/{DebateCouncil,Demo,DeveloperCouncil,ProductCouncil,KnowledgeCo
 
 Expected: all 5 council skills present after `make install-skills-codex` (workspace mode).
 
+## Codex role config
+
+```bash
+ls .codex/agents/{SoftwareDeveloper,DatabaseEngineer,DevOpsEngineer,DocumentationWriter,QaTester,SecurityArchitect,SystemArchitect,UxDesigner,ProductManager,DataAnalyst,TheOpponent,WebResearcher,ForensicAgent}.toml
+ls .codex/agents/{SoftwareDeveloper,DatabaseEngineer,DevOpsEngineer,DocumentationWriter,QaTester,SecurityArchitect,SystemArchitect,UxDesigner,ProductManager,DataAnalyst,TheOpponent,WebResearcher,ForensicAgent}.prompt.md
+test -f .codex/agents/forge-council-agents.toml && echo "ok manifest"
+grep -n "BEGIN forge-council agents" .codex/config.toml
+```
+
+Expected: all Codex role artifacts present after `make install-codex-agent-config` (or `make install`), and `.codex/config.toml` contains the forge-council role block markers.
+
 ## Agent teams (optional)
 
 ```bash

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -116,10 +116,13 @@ providers:
 
     codex:
         models:
-            - claude-opus-4-6
-            - claude-sonnet-4-6
-        fast: claude-sonnet-4-6
-        strong: claude-opus-4-6
+            - gpt-5.3-codex
+            - gpt-5.2-codex
+            - gpt-5.1-codex-max
+            - gpt-5.2
+            - gpt-5.1-codex-mini
+        fast: gpt-5.1-codex-mini
+        strong: gpt-5.3-codex
 
     opencode:
         models:


### PR DESCRIPTION
- update Codex model mapping in defaults.yaml

- add temporary bash codex post-processing helper with config.yaml/defaults.yaml parsing (until added to rust lib)

- generate relative Codex role config_file/prompt_file entries and model_reasoning_effort mapping

- wire install-codex-agent-config as explicit Makefile post-processing step

- update README, INSTALL, AGENTS, VERIFY docs for Codex role generation, replace "collab" with "multi_agent"

- TODO: AGENTS.md seems behind CLAUDE.md. Needs merging with CLAUDE.md