### PR TITLE
fix: wire jj push gate on make install, standardize Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,26 @@
-# forge-council
-
 FORGE ?= forge
 
 .PHONY: help install validate release clean
 
 help:
-	@echo "  make install    deploy and activate git hooks"
-	@echo "  make validate   validate module structure and code"
-	@echo "  make release    build release tarball (no forge CLI needed to install)"
+	@echo "  make install    deploy content and install the git hooks"
+	@echo "  make validate   run all checks (commit + pre-push stages)"
+	@echo "  make release    build release tarball"
 	@echo "  make clean      remove build artifacts"
 
 install:
 	@command -v $(FORGE) >/dev/null 2>&1 \
 	    || { echo "forge not found — ask an AI assistant to execute INSTALL.md"; exit 1; }
 	git config core.hooksPath .githooks
+	chmod +x .githooks/* 2>/dev/null || true
 	$(FORGE) install --target ~
 
 validate:
 	@bash .githooks/pre-commit
+	@bash .githooks/pre-push
+
+release:
+	$(FORGE) release
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
Standardizes the Makefile. `make install` deploys content via the forge CLI and installs the git hooks (`core.hooksPath`); `validate` now runs both the commit and pre-push stages so it can't pass while skipping the secret scan; and it adds the `release` target that was declared in `.PHONY` with no recipe.

The jj `push` gate is a global jj alias (set by provisioning), not per-repo Makefile state.
