### PR TITLE
feat: add StagedDelivery and ProjectInit skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dist/
 
 # OS
 .DS_Store
+
+# Parallel checkouts
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `skills/ProjectInit/SKILL.md` -- deep scoping interview that establishes a new project: local git tracking, distilled `CLAUDE.md`, project-scoped `.claude/rules/` every subagent inherits, and a `DEFERRED.md` seed. Includes a `refresh` mode that re-interviews only drifted areas. StagedDelivery is the natural follow-up loop; both stand alone.
 - `skills/StagedDelivery/SKILL.md` -- council-first plan/build/verify loop: routes scope to DeveloperCouncil/ProductCouncil/KnowledgeCouncil (individual specialists only when no council fits), a conditional opponent gate, a user/file decision gate, and a deferred-menu ledger. Stays in-module; forge-core skills are optional. Optional per-prompt reinforcement hook documented for manual wiring in `INSTALL.md` (not deployed by forge).
 - `rules/AgentTeams.md` -- documents the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` gate, mandatory teardown protocol, and the known upstream agent-team bugs (#49671, #53160, #55824, #59717).
 - Step 0 gate check inline in every council skill (DebateCouncil, DeveloperCouncil, ProductCouncil, KnowledgeCouncil, HiringCouncil) -- replaces the previous `@AgentTeams.md` injection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `skills/StagedDelivery/SKILL.md` -- council-first plan/build/verify loop: routes scope to DeveloperCouncil/ProductCouncil/KnowledgeCouncil (individual specialists only when no council fits), a conditional opponent gate, a user/file decision gate, and a deferred-menu ledger. Stays in-module; forge-core skills are optional. Optional per-prompt reinforcement hook documented for manual wiring in `INSTALL.md` (not deployed by forge).
 - `rules/AgentTeams.md` -- documents the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` gate, mandatory teardown protocol, and the known upstream agent-team bugs (#49671, #53160, #55824, #59717).
 - Step 0 gate check inline in every council skill (DebateCouncil, DeveloperCouncil, ProductCouncil, KnowledgeCouncil, HiringCouncil) -- replaces the previous `@AgentTeams.md` injection.
 - `.githooks/pre-commit` with `prek` / `forge validate` cascade and hash-verified `validate.sh` fallback (canonical source: forge-cli `templates/init/.githooks/pre-commit`).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,6 @@ Deploy forge-council agents, council skills, and rules to all AI providers via M
 git clone https://github.com/N4M3Z/forge-council.git
 cd forge-council
 ```
-
 If already cloned, pull latest:
 
 ```sh
@@ -128,4 +127,3 @@ Then add to `~/.claude/settings.json`, pointing at the absolute path where you s
     }
 }
 ```
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,3 +85,47 @@ git config core.hooksPath
 Should return `.githooks`.
 
 EXECUTE NOW: Complete the above TODO list.
+
+## Optional: StagedDelivery reinforcement hook
+
+The `StagedDelivery` skill works on its own. Its per-prompt reinforcement is an
+optional `UserPromptSubmit` hook, wired by hand — `make install` does not deploy
+runtime hooks. Skip this section unless you want the loop restated each prompt.
+
+Save the hook script (e.g. to `~/.config/staged-delivery/reinforce.sh`) and
+`chmod +x` it:
+
+```bash
+#!/usr/bin/env bash
+# UserPromptSubmit hook: reinforce the StagedDelivery loop while the session is armed.
+# Opt-in — silent unless ~/.config/staged-delivery/armed exists (the skill arms it;
+# "stop staged delivery" disarms). Always exits 0; communicates via stdout JSON only.
+set -u
+ARMED="${HOME}/.config/staged-delivery/armed"
+[ -f "$ARMED" ] || exit 0
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"STAGED DELIVERY ACTIVE. For substantive work run the loop: (1) council — 2-4 relevant specialists in parallel, code-grounded, cite file:line; (2) opponent gate (TheOpponent) — verify vs code, kill gold-plating, output a staged plan + the single riskiest thing; (3) user/file decision gate — never auto-pick scope; (4) build staged — branch per feature, commit per stage, TaskCreate per stage; (5) verify suites separately + self-checks, sequential DB runs only; (6) ponytail the diff; (7) land — CHANGELOG, ff-merge, honest caveats; append leftovers to DEFERRED.md. Assume caveman (terse prose) and ponytail (lazy, shortest diff) are active. Trivial edits skip the loop. 'stop staged delivery' to disarm."}}
+JSON
+exit 0
+```
+
+Then add to `~/.claude/settings.json`, pointing at the absolute path where you saved it:
+
+```json
+{
+    "hooks": {
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash \"$HOME/.config/staged-delivery/reinforce.sh\"",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Without the flag, councils fall back to sequential subagent calls — same speci
 | `/ProductCouncil` | Requirements review, feature scoping, strategy with PM, UxDesigner, SoftwareDeveloper, DataAnalyst |
 | `/KnowledgeCouncil` | Knowledge architecture and memory lifecycle decisions with DocumentationWriter, SystemArchitect, WebResearcher |
 | `/HiringCouncil` | Job postings, role design, compensation, recruitment strategy |
+| `/ProjectInit` | Deep scoping interview establishing a new project: local git, `CLAUDE.md`, project-scoped rules, `DEFERRED.md` seed |
+| `/StagedDelivery` | Council-first plan/build/verify loop with opponent gate, decision gate, and deferred ledger; natural follow-up to `/ProjectInit` |
 
 ### Debate modes
 

--- a/skills/ProjectInit/SKILL.md
+++ b/skills/ProjectInit/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ProjectInit
+version: 0.1.0
+description: "Establish a new project through a deep scoping interview -- distill the goal, set up local git tracking, and write project-scoped rules every subagent inherits. USE WHEN starting a new project, initializing a workspace, new research/analysis/coding effort, project kickoff, 'set up this project', or refreshing a project's rules after scope drift."
+argument-hint: "[project directory, defaults to cwd] [refresh]"
+---
+
+# Project Init
+
+You establish a project once, so every later session and every subagent starts oriented. The deliverable is not conversation -- it is a tracked workspace: local git, a distilled `CLAUDE.md`, and project-scoped rules under `.claude/rules/` that all subagents inherit. StagedDelivery is the natural follow-up loop, but this skill stands alone for any project type: research, discussion, coding, or data analysis.
+
+**Module boundary.** Everything here uses native mechanisms (git, `CLAUDE.md`, `.claude/rules/`). Other-module skills (`Brainstorming` from forge-core) are optional enhancements: use them when installed, degrade gracefully when not.
+
+## The interview
+
+Dig deep before writing anything. Iterative `AskUserQuestion` rounds -- keep asking until the answers stop changing what you would write. Minimum ground to cover:
+
+1. **Type and goal.** Research, discussion, coding, or data analysis? What does done look like -- the one-sentence outcome, and the measurable success criterion behind it.
+2. **Scope edges.** What is explicitly out of scope. What already exists (data, code, documents, prior art) that the project builds on.
+3. **Constraints.** Deadlines, tools that must or must not be used, external dependencies, compliance or privacy boundaries.
+4. **Audience and voice.** Who consumes the output. Wording conventions, language, tone, terminology that must stay consistent.
+5. **Visual consistency** (only when the project produces visual output). Color/typography/plot styling conventions, figure standards, templates to follow.
+6. **Subagent context.** What must every spawned agent know without being told -- the facts that, if missing, make delegated work drift.
+
+If the goal itself is still fuzzy after round one, run `Brainstorming` (when installed) to explore the space, then resume the interview with its output.
+
+Follow-up rounds react to answers: a research project gets asked about venues and evidence standards; a coding project about stack, testing, and review gates; a data-analysis project about data provenance and reproducibility. Do not ask template questions the earlier answers already settled.
+
+## The outputs
+
+Write these in the project directory, in this order:
+
+1. **Git tracking (local).** If no repo exists: `git init` (branch `main`), a `.gitignore` seeded for the project type, and an initial commit of the scaffold below. Never create a remote or push -- local tracking is the requirement.
+2. **`CLAUDE.md`.** The distilled interview: goal, success criteria, scope edges, constraints, audience. Short -- it loads every session. Facts, not transcript.
+3. **`.claude/rules/ProjectGoal.md`** -- always. The one rule every subagent inherits: what this project is, what done means, what is out of scope. Write it so a subagent with zero other context acts correctly.
+4. **`.claude/rules/<Aspect>.md`** -- only for aspects the interview actually surfaced. Wording/terminology conventions, visual consistency standards, evidence or testing gates. One rule per aspect, PascalCase names, concise bodies. Do not write rules for things the interview never mentioned.
+5. **`DEFERRED.md`** -- empty ledger seed (a heading and the format line), so StagedDelivery can resume scope from a file rather than context.
+
+Stage everything, show the user the diff, commit on approval (conventional commits).
+
+## Rule freshness
+
+Rules rot when the project drifts. Instruct the session (and note it in `CLAUDE.md`):
+
+- When the user corrects the same assumption 3+ times, or the goal/scope visibly shifts, propose the matching rule edit -- do not wait to be asked.
+- `ProjectInit refresh` re-runs the interview only for the drifted areas: read the existing `CLAUDE.md` and rules first, ask only about what changed, rewrite only the affected files. Never re-interview from scratch when a refresh was requested.
+
+## Handoff
+
+Close by offering the follow-up loop: arm `StagedDelivery` for iterative delivery inside the newly scoped project. If StagedDelivery is not installed, say the project is initialized and stop -- the outputs stand on their own.
+
+## Constraints
+
+- Interview before writing. Never scaffold from assumptions the user did not confirm.
+- The user owns the answers. Present distilled drafts for approval; never invent goals, style guides, or constraints that were not said.
+- Local git only -- no remotes, no pushes, unless the user explicitly asks.
+- Rules are scoped to what was surfaced. No boilerplate rule packs; an aspect nobody mentioned gets no rule.
+- `CLAUDE.md` and rules are token-costly context -- keep them short and factual.
+- Refresh mode edits only drifted files; it never rewrites a healthy scaffold.

--- a/skills/StagedDelivery/SKILL.md
+++ b/skills/StagedDelivery/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: StagedDelivery
+version: 0.1.0
+description: "Plan via adversarial council, then build in verified stages with per-stage commits. USE WHEN building a feature batch, continuing a roadmap ('continue'), council-plan + opponent-review + staged implementation, iterative delivery loop, or running a headless file-feedback build loop."
+argument-hint: "[feature/scope to plan, or 'continue' to take the top deferred item] [interactive|file-feedback]"
+---
+
+# Staged Delivery
+
+You orchestrate a **plan → build → verify** loop. You do NOT reinvent councils or verification — you route to an existing council (DeveloperCouncil, ProductCouncil, KnowledgeCouncil) and add three things a council lacks: an **opponent gate**, a **user/file decision gate**, and a **deferred-menu ledger** so any window can resume.
+
+**Module boundary.** Route only within this module (forge-council councils + agents) — those are always present when StagedDelivery is. Other-module skills (`ExecutePlan`, `StagedReview`, `VerifyCompletion`, `LearnFrom` from forge-core; `ponytail-review`) are **optional enhancements: use them when installed, degrade gracefully when not.** Never hard-depend on a skill outside forge-council.
+
+This skill is **opt-in per session**. On invocation, **arm the session** so a UserPromptSubmit hook reinforces the loop every prompt (mirrors caveman/ponytail):
+
+```sh
+mkdir -p ~/.config/staged-delivery && touch ~/.config/staged-delivery/armed
+```
+
+Disarm on "stop staged delivery" / "normal mode": `rm -f ~/.config/staged-delivery/armed`. Once armed, run every substantive feature this way until disarmed. Trivial edits skip the loop.
+
+The reinforcement hook is optional and wired by hand — forge does not deploy runtime hooks. See [INSTALL.md](../../INSTALL.md) for the script and the `settings.json` snippet. Without the hook the skill still works; you lose only the per-prompt restatement.
+
+**Assumes caveman + ponytail are active too.** This loop pairs with them: caveman governs prose (terse, drop filler — write code/commits normally), ponytail governs what you build (the ladder: does it need to exist? stdlib? native? one line? then minimal code — shortest working diff wins). If they are not loaded, behave as if they were: terse output, smallest correct diff. The reinforcement hook restates all three each prompt.
+
+## The loop
+
+For each unit of work (a feature batch, or one "continue"):
+
+1. **Scope.** Take the user's named scope, or the top item from `DEFERRED.md` (see Ledger). State what you're about to plan.
+
+2. **Route to a council — code-grounded.** Classify the scope, convene the matching council skill (it owns roster selection; don't hand-assemble one):
+
+   | Scope | Council |
+   |---|---|
+   | any implementation, code review, architecture, debugging | DeveloperCouncil |
+   | requirements, feature scoping, go/no-go, prioritization | ProductCouncil |
+   | docs, skills, rules, vault/note architecture | KnowledgeCouncil |
+
+   Pass the scope to the council as its topic. Tell its specialists to read real files and cite `file:line` — no theorizing.
+
+   **2b. No council fits (fallback only).** For a lone-file review or one narrow specialty where no council applies, spawn 1-2 individual forge-council specialists directly instead — `SoftwareDeveloper`/`QaTester` (implementation), `DatabaseEngineer` (schema), `SecurityArchitect` (threat model), `SystemArchitect` (boundaries), `UxDesigner` (flows), `WebResearcher` (external facts, verify don't fabricate). This is the exception, not the default. A scientific/paper "build" is not a code loop — hand it to forge-science's ScientificCouncil directly rather than routing here.
+
+3. **Opponent gate.** The gate is mandatory; how it runs depends on the route:
+   - **DeveloperCouncil** seats no adversary by default — spawn a standalone `TheOpponent` over the council's output.
+   - **ProductCouncil / KnowledgeCouncil** — append `"with opponent"` to the invocation so the council seats `TheOpponent` itself, then this step is a **gate-check** on the returned verdict.
+   - **2b fallback** — spawn a standalone `TheOpponent` over the specialist output.
+
+   However it runs, the verdict MUST: verify claims against code, resolve conflicts, **kill gold-plating**, and emit (a) a **staged build plan** where each stage is independently shippable + testable, and (b) the **single riskiest thing**. A verdict missing the riskiest-thing line is incomplete — bounce it back.
+
+4. **Decision gate — user chooses, never auto-pick.** Surface only the *verified* forks. Two modes:
+   - **Interactive**: `AskUserQuestion` with the options (recommended first, "(Recommended)").
+   - **File-feedback** (headless/continuous): write the plan + forks to `.staged-delivery/plan-NNN.md`, set status `AWAITING_FEEDBACK`, and wait for `.staged-delivery/feedback-NNN.md`. See **File-feedback loop** below.
+   Never expand scope beyond what was chosen.
+
+5. **Stage the build.** Branch per feature (`feat/<slug>`). `TaskCreate` one task per stage so the work is resumable. Build in dependency order: model → migration → service → routes → template. **Commit per stage** (conventional commits, no Co-Authored-By unless asked).
+
+6. **Verify every stage.** Run suites *separately* (unit / integration / migration / e2e) + linter. Pure logic modules carry a runnable `_self_check()` / `if __name__ == "__main__"`. Verify external-behavior claims empirically (run both tools, show matching output) — never assert a tool/API/constant you didn't check. **Never fan out repeated full-suite runs against a shared DB — sequential only** (concurrent runs truncate each other and manufacture flakes).
+
+7. **Ponytail the diff.** Cut speculative flexibility, hand-rolled stdlib, single-impl abstractions. Shortest working diff wins. (Invoke ponytail-review if available.)
+
+8. **Land.** Update CHANGELOG, ff-merge to main, delete the branch. State **honest caveats**: what's deferred, model ceilings, "estimate not guarantee", what abstains/refuses. Append new deferred items to the Ledger.
+
+After a batch with transferable learnings (a teardown, a rename touching many files, 3+ user corrections), invoke `LearnFrom`.
+
+## Deferred-menu ledger
+
+Keep `DEFERRED.md` at repo root (or `.staged-delivery/DEFERRED.md`). Every council pass emits items not chosen — append them with a one-line rationale and a value tag. "Continue" reads the top item. This is what makes the loop resumable in a different window: state lives in the file, not in context.
+
+## File-feedback loop (headless / continuous)
+
+For running without a human at the terminal, replace the interactive decision gate with files under `.staged-delivery/`:
+
+- `plan-NNN.md` — council + opponent verdict, the forks as a checklist, a `status:` header (`AWAITING_FEEDBACK` | `APPROVED` | `CHANGES`).
+- `feedback-NNN.md` — the decision. Two ways to produce it:
+  1. **Human**: edits the file, picks options, sets `status: APPROVED`.
+  2. **Verifier agents**: spawn a small reviewer panel (2-3 agents: a skeptic, a domain checker, a scope-cutter) that critique the plan and write a consensus decision + `status:`. Use this to fully close the loop with no human.
+- Poll with `/loop` + `ScheduleWakeup` (long interval, 1200s+ when idle; short only when actively waiting on a just-written file). On `APPROVED` → implement stages → write `result-NNN.md` → start cycle NNN+1 from the Ledger. On `CHANGES` → re-run the opponent gate with the feedback.
+
+Keep `state.json` (`{cycle, phase, branch}`) so a fresh window resumes mid-loop.
+
+## Constraints
+
+- Council first. A council is the default; individual specialists (2b) are the exception, used only when no council covers the scope. Never hand-assemble a specialist roster when a council fits.
+- Stay in-module. Route only to forge-council councils/agents; treat forge-core and other skills as optional, and degrade gracefully when they are absent.
+- Code-grounded everything. Read before asserting; cite `file:line`.
+- The user owns scope. Never auto-expand; never pick a fork for them in interactive mode.
+- One feature = one branch = staged commits. Don't batch unrelated work.
+- Opponent output is mandatory before any code.
+- Trivial/mechanical edits skip the whole loop — say so and just do them.
+- Honest caveats always; no overclaiming "done" without the verification output behind it.


### PR DESCRIPTION
## Problem

forge-council convenes councils and runs standalone specialists, but there is no
skill that drives a full **plan → build → verify** delivery loop on top of them.
Feature work done ad hoc tends to skip the adversarial review a council provides,
loses resumability across sessions/windows, and lets scope creep in unchecked.

## Approach

Add a `StagedDelivery` skill: a council-first orchestration loop that sequences
existing councils and adds the three things a council alone lacks — an **opponent
gate**, a **user/file decision gate**, and a **deferred-menu ledger** for
resumability. It reuses councils and verification skills; it does not reimplement
them.

### How it works

For each unit of work (a named feature, or `continue` to pull the top ledger item):

1. **Scope** — state what is about to be planned (from the user or `DEFERRED.md`).
2. **Route to a council** — classify the scope and convene the matching council,
   letting the council own roster selection:
   - implementation / code review / architecture / debugging → `DeveloperCouncil`
   - requirements / scoping / go-no-go → `ProductCouncil`
   - docs / skills / rules / vault architecture → `KnowledgeCouncil`
   - **2b fallback** — only when no council fits (a lone-file review, one narrow
     specialty), spawn 1-2 individual specialists directly.
3. **Opponent gate (mandatory, conditional on route)** — `DeveloperCouncil` seats
   no adversary by default, so a standalone `TheOpponent` runs over its output;
   `ProductCouncil` / `KnowledgeCouncil` are invoked `with opponent` and this step
   becomes a gate-check. Either way the verdict must carry a staged build plan
   (each stage independently shippable + testable) and the single riskiest thing.
4. **Decision gate** — surface the verified forks; the user picks scope (interactive
   `AskUserQuestion`, or a file-feedback handshake for headless runs). Never
   auto-expand.
5. **Stage the build** — branch per feature, one task per stage, commit per stage.
6. **Verify** — suites run separately, self-checks on pure logic, sequential DB runs.
7. **Ponytail the diff** — cut speculative flexibility; shortest working diff.
8. **Land** — CHANGELOG, ff-merge, honest caveats; append leftovers to the ledger.

### Use case

Batch or iterative feature delivery where correctness and reviewability matter more
than raw speed: building a roadmap item by item, resuming a half-finished stream in
a fresh window (state lives in `DEFERRED.md` + `.staged-delivery/`, not in context),
or running a headless build loop where verifier agents produce the decision instead
of a human. Trivial/mechanical edits skip the loop entirely.

### Module boundary

The skill routes only within forge-council (its councils + agents are always present
when it is). Cross-module skills (`ExecutePlan`, `StagedReview`, `VerifyCompletion`,
`LearnFrom` from forge-core; `ponytail-review`) are optional enhancements used when
installed and degraded gracefully when absent — no hard dependency on any skill
outside this module.

## ProjectInit companion

`skills/ProjectInit/SKILL.md` pairs with the loop from the other end: a deep
`AskUserQuestion` scoping interview that establishes a new project before any
delivery starts. Outputs are native mechanisms only — local git tracking (`git
init`, `.gitignore` seed, initial commit), a distilled `CLAUDE.md`, project-scoped
`.claude/rules/` every subagent inherits (always a project-goal rule; style and
consistency rules only when the interview surfaces them), and a `DEFERRED.md` seed
for the ledger. A `refresh` mode re-interviews only drifted areas. ProjectInit
closes by offering StagedDelivery; both stand alone.

## Out of scope

- The optional per-prompt reinforcement hook is **not** deployed by `make install`
  (forge does not deploy runtime hooks). It is documented for manual wiring in
  `INSTALL.md` (script + `settings.json` snippet).
- `HiringCouncil`, `ScientificCouncil`, and `DebateCouncil` are deliberately not
  routing targets: hiring is irrelevant to a build loop, scientific work belongs to
  its own module, and a cross-domain catch-all overlaps `DeveloperCouncil` too much
  to route reliably.

## Test plan

- [x] `make validate` passes with the new skill (required H1 present, frontmatter valid)
- [x] Skill installs and loads (`skills/StagedDelivery/SKILL.md`)
- [x] `forge validate` passes with `skills/ProjectInit/SKILL.md` added
- [ ] Reviewer confirms routing table matches the council skills' own USE-WHEN triggers
- [ ] ProjectInit walk-through on a fresh directory produces git repo + `CLAUDE.md` + rules

